### PR TITLE
fix(algoliaplaces): templates proptypes

### DIFF
--- a/src/AlgoliaPlaces.js
+++ b/src/AlgoliaPlaces.js
@@ -47,8 +47,8 @@ export default class AlgoliaPlaces extends React.Component {
       aroundLatLngViaIP: PropTypes.bool,
       aroundRadius: PropTypes.number,
       templates: PropTypes.shape({
-        suggestion: PropTypes.string,
-        value: PropTypes.string,
+        suggestion: PropTypes.func,
+        value: PropTypes.func,
       }),
       style: PropTypes.bool,
       appId: PropTypes.string,


### PR DESCRIPTION
The `places.js` library takes in functions for the `options.templates` properties, not strings. The return type is string, but a function should be passed.

https://community.algolia.com/places/documentation.html#suggestions

Here's a usage example:

`templates: {
                suggestion: ({ name, city, administrative }) => {
                  return '
                    <span class="ap-name">${name}</span> 
                    <span class="ap-address">${city}, ${administrative}</span>
                  '
                },
                value: ({ name, city, administrative }) => {
                  return '${name}, ${city}, ${administrative}'
                }
              }`